### PR TITLE
Clarify WordPress API instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 1. [Integrating with Axate](./docs/readme.md)
 2. [Providing an API for Content Retrieval](./docs/content-api.md)
-3. [Using WP-REST API (only for Wordpress)](./docs/wordpress-api.md)
+3. [Using WP-REST API (only for WordPress)](./docs/wordpress-api.md)
 4. [Incorporating Subscribtions](./docs/subscriptions-api.md)
 5. [Testing & Go Live](./docs/testing-and-go-live.md)
 
@@ -28,7 +28,7 @@
 * [Marketing consents](./docs/marketing-consents.md)
 * [Selective loading](.docs/selective_loading.md)
 * [Troubleshooting](./docs/troubleshooting.md)
-* [Wordpress API](./docs/wordpress-api.md)
+* [WordPress API](./docs/wordpress-api.md)
 
 ## SEO Considerations
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -71,7 +71,7 @@ data-selector-banner-contribution=".AxateContributionBanner">
 <div class="AxateContributionBanner"></div>
 ```
 
-## Wordpress
+## WordPress
 
 Editing the functions.php file
 
@@ -123,5 +123,5 @@ All these can be added to wallet, to enable, or disable axate functionalities pe
 ### Next Steps
 
 2. [Providing an API for Content Retrieval](./content-api.md)
-3. [Using WP-REST API (only for Wordpress)](./wordpress-api.md)
+3. [Using WP-REST API (only for WordPress)](./wordpress-api.md)
 4. [Incorporating Subscribtions](./subscriptions-api.md)

--- a/docs/wordpress-api.md
+++ b/docs/wordpress-api.md
@@ -1,6 +1,6 @@
-## Wordpress API Integration
+## WordPress API Integration
 
-Current Wordpress versions come with a REST API enabled by default, and can be consumed easily by any developer application, such as Axate.
+Current WordPress versions come with a REST API enabled by default, and can be consumed easily by any developer application, such as Axate.
 
 Let’s take for example this article,
  - https://en-gb.wordpress.org/2019/01/15/glasgow-meetup-1st-quarter-2019/
@@ -22,7 +22,7 @@ Since you would not want a tech-savvy user to have access to this API publicly, 
 
 
 One middle step is to ensure, the content is not present on the Template that is responsible for printing it out to normal users. 
-That means within the single.php we will remove the wp-content tag that 
+That means within `single.php` you should remove the `the_content()` call that normally outputs the article body. 
 
 
 There can be further steps to secure API access, so that it can be private only to Agate servers and therefore guarantee that only a request from us would be treated as a condition to reveal content, but these require custom development, feel free to get in touch with us and we can always work on a solution together.


### PR DESCRIPTION
## Summary
- update WordPress capitalization in docs
- finish the incomplete instruction about removing `the_content()` in the WordPress API guide

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a99d14fd88323b5721c5f17a728e8