### PR TITLE
Fix typos in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 
 1. [Integrating with Axate](./docs/readme.md)
 2. [Providing an API for Content Retrieval](./docs/content-api.md)
-3. [Using WP-REST API (only for Wordpress)](./docs/wordpress-api.md)
-4. [Incorporating Subscribtions](./docs/subscriptions-api.md)
+3. [Using WP-REST API (only for WordPress)](./docs/wordpress-api.md)
+4. [Incorporating Subscriptions](./docs/subscriptions-api.md)
 5. [Testing & Go Live](./docs/testing-and-go-live.md)
 
 ## General
@@ -28,7 +28,7 @@
 * [Marketing consents](./docs/marketing-consents.md)
 * [Selective loading](.docs/selective_loading.md)
 * [Troubleshooting](./docs/troubleshooting.md)
-* [Wordpress API](./docs/wordpress-api.md)
+* [WordPress API](./docs/wordpress-api.md)
 
 ## SEO Considerations
 

--- a/docs/analytics-hooks.md
+++ b/docs/analytics-hooks.md
@@ -1,4 +1,4 @@
-# Javascripts Hooks
+# JavaScript Hooks
 
 Axate offers various functions to manage user interactions with the Axate wallet, both before and after login, and when premium content is accessed.
 
@@ -7,19 +7,19 @@ These functions can be integrated for purposes such as setting user cookies, tra
 The current flow includes the following functions:
 
 * `axateInit()`: Triggered when the Axate script is initialized.
-* `agateUserLoggedIn()`: Triggered once each time a user is logs in.
+* `agateUserLoggedIn()`: Triggered once each time a user logs in.
 * `agateUserLoggedOut()`: Triggered when a user logs out.
 * `axateUserHasAccessToContent()`: Triggered when a user gains access to content.
 * `agatePremiumContentRendered()`: Triggered when a premium article is purchased.
 
-Transaction based Hooks
+Transaction-based Hooks
 * `axateUserOnFreePeriod()`: Triggered when a user has reached the free period, only once per achievement of Free Period.
 * `axatePaidTransaction()`: Triggered when a user used real money to pay for transaction.
-* `axateBonusReadTransaction`:Triggered when a user used bonus money to pay for transaction.
-* `axateFreePeriodTransaction()`: Triggered when a user has read for free, on weekly/daily period.
+* `axateBonusReadTransaction`: Triggered when a user used bonus money to pay for transaction.
+* `axateFreePeriodTransaction()`: Triggered when a user has read for free during a weekly/daily period.
 * `axateAlreadyReadTransaction()`: Triggered when a user has already read the article.
 
-Page Notices based hooks
+Page Notice-based hooks
 * `axatePayNow()` - In the just read/charge automatically Page Notice, if a user chooses Pay Now and remind me later
 * `axateSetChargeAutomaticallyFromNow()` - In the just read/charge automatically Page Notice, if a user chooses Pay Now and don't remind me later
 
@@ -28,7 +28,7 @@ Page Notices based hooks
 
 For Axate hooks to work you have to have Axate Wallet available on every page the hook is called.
 
-In order to use use it, you use the JavaScript window object.
+In order to use it, you use the JavaScript window object.
 
 Example: window.axateContribute()
 
@@ -50,7 +50,7 @@ function agatePremiumContentRendered() {
 
 };
 ```
-In this example, a subscription offer is ommited after an Axate User has purchased an article via Axate.
+In this example, a subscription offer is omitted after an Axate user has purchased an article via Axate.
 
 Example: 
 
@@ -99,7 +99,7 @@ Some publishers may utilise third-party solutions (such as Adobe Experience Mana
 
 ## Why can't we just use `data-` attributes?
 
-Typical we would be able to add `data-axate-login` or something similar to allow analytics to hook onto `DOM` elements with ease, however in this context the `wallet` is within an iframe, so due to security (accessing Elements in a Cross-Origin Iframe) this is not setup.
+Typically we would be able to add `data-axate-login` or something similar to allow analytics to hook onto `DOM` elements with ease; however, in this context the `wallet` is within an iframe, so due to security (accessing elements in a cross-origin iframe) this is not set up.
 
 ## We’ve got a race condition, we’re waiting for Axate to load, what can we do?
 

--- a/docs/browser-support.md
+++ b/docs/browser-support.md
@@ -9,7 +9,7 @@
 ---
 
 As a general rule, we support [evergreen browsers](https://www.techopedia.com/definition/31094/evergreen-browser) current version, and 2 previous versions. 
-Axate officially support the following browsers and operating systems:
+Axate officially supports the following browsers and operating systems:
 
 &nbsp;
 
@@ -21,10 +21,10 @@ Axate officially support the following browsers and operating systems:
 |:----------------|:-------------------|:---------------------------|:-------------------------------|
 | Microsoft Edge  | Blink and EdgeHTML | 80, 18, 17, 16             | Windows, macOS                 |
 | Mozilla Firefox | Gecko              | 71, 70, 69, 68             | Android, Windows, macOS, Linux |
-| Google Chrome   | Blink              | 78, 77, 76, 75.            | Android, Windows, macOS, Linix |
+| Google Chrome   | Blink              | 78, 77, 76, 75.            | Android, Windows, macOS, Linux |
 | Safari          | WebKit             | 13<sup>a</sup>, 12, 11     | macOS, iOS and iPadOS          |
 
-> Note: you'll likely find find older browser versions will still work. Sadly we don't provide official support for these browsers.
+> Note: you'll likely find older browser versions will still work. Sadly we don't provide official support for these browsers.
 > Update: we've recently found that Safari 13.0.4 on macOS 10.15.2 is temporarily not fully supported.
 > 
 > <sup>a.</sup> For end user/consumer information, see: [Axate and Apple Safari](https://www.axate.com/safari-faqs). 
@@ -36,7 +36,7 @@ Axate officially support the following browsers and operating systems:
 ### Other Supported Browsers
 ---
 
-As many browser share the same rendering engine as the major browsers above, the following web browsers are also supported:
+As many browsers share the same rendering engine as the major browsers above, the following web browsers are also supported:
 
 
 **Blink**  

--- a/docs/content-api.md
+++ b/docs/content-api.md
@@ -31,4 +31,4 @@ In both these steps, we will work with you to make Axate work with your system a
 
 ### Next Steps
 
-4. [Incorporating Subscribtions](./subscriptions-api.md)
+4. [Incorporating Subscriptions](./subscriptions-api.md)

--- a/docs/marketing-consents.md
+++ b/docs/marketing-consents.md
@@ -4,7 +4,7 @@ A regular Marketing Consents dialog features one opt-in at registration for all 
 
 <img width="466" alt="Screenshot 2023-10-27 at 14 50 15" src="https://github.com/AgateHQ/axate-developer-docs/assets/1307523/032893d9-4a23-41c0-91f5-2874b813e866">
 
-We can provide you with an export csv of emails who consented to the marketing.
+We can provide you with an export CSV of emails who consented to the marketing.
 
-In special circunstances we can push them to your API, or Email/Newsletter Services.
+In special circumstances we can push them to your API, or email/newsletter services.
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -71,7 +71,7 @@ data-selector-banner-contribution=".AxateContributionBanner">
 <div class="AxateContributionBanner"></div>
 ```
 
-## Wordpress
+## WordPress
 
 Editing the functions.php file
 
@@ -123,5 +123,5 @@ All these can be added to wallet, to enable, or disable axate functionalities pe
 ### Next Steps
 
 2. [Providing an API for Content Retrieval](./content-api.md)
-3. [Using WP-REST API (only for Wordpress)](./wordpress-api.md)
-4. [Incorporating Subscribtions](./subscriptions-api.md)
+3. [Using WP-REST API (only for WordPress)](./wordpress-api.md)
+4. [Incorporating Subscriptions](./subscriptions-api.md)

--- a/docs/testing-and-go-live.md
+++ b/docs/testing-and-go-live.md
@@ -9,7 +9,7 @@ Although PayPal and Apple Pay will be available to your users when your implemen
 
 ### On Live, prior to Go Live
 
-  1. Mark 10 - 15 articles on your staging site as premium Add the live Axate code only to those articles
+  1. Mark 10 - 15 articles on your staging site as premium. Add the live Axate code only to those articles
   2. Provide us with the URLs of those articles
 
 We recommend testing on the live environment prior to full go-live. To do this, mark as premium a few articles that are unlikely to be found organically (i.e. older articles or not currently topical). We recommend a sample of 10 to 15 articles for testing.
@@ -22,11 +22,11 @@ The staging code is this:
 
 ``` <script async src="https://wallet-staging.agate.io/bundle.js"></script> ```
 
-To make it like, delete word “staging” so that it appears like this:
+To make it live, delete the word “staging” so that it appears like this:
 
 ``` <script async src="https://wallet.agate.io/bundle.js"></script> ```
 
-You should see Agate briefly if the page is still loading.
+You should see Axate briefly if the page is still loading.
 
 On our side, we need to switch page notices etc over to our live database, so please let us know when you are ready to carry out the live testing.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,13 +4,13 @@
 
 ### Axate Tab/Wallet Blocking important content
 
-If the Axate tab appears over an important piece of content, such as a header of the website, or a sidebar with a piece of important information, you can easily adjust where Axate is sitting on the left site by modyfing the CSS that sets the Axate container, to do this, feel free to adjust this code on your side.
+If the Axate tab appears over an important piece of content, such as a header of the website or a sidebar with a piece of important information, you can easily adjust where Axate is sitting on the left side by modifying the CSS that sets the Axate container. Feel free to adjust this code on your side.
 
 > TBC
 
 ### Axate callbacks
 
-Axate uses callbacks to allow you inject special functionality or internal analytics in various pre-payment or post-payment callbacks, to acess these you can use the functions:
+Axate uses callbacks to allow you to inject special functionality or internal analytics in various pre-payment or post-payment callbacks. To access these you can use the functions:
 
 > TBC
 
@@ -20,7 +20,7 @@ Axate relies on two cookies, one functional and one for analytics purposes, whic
 
 Users can opt-out of analytics cookies on their account page, or even block it by any AdBlocker or Tracking Blocking software on their browser, but they should allow the main functional cookie to be set.
 
-That cookie is named `agate_cookie`, and comes from `https://account.agate.io` , it is an HttpOnly cookie and always Secure to prevent any other site using it for any potentially malicous purposes.
+That cookie is named `agate_cookie` and comes from `https://account.agate.io`. It is an HttpOnly cookie and always secure to prevent any other site using it for any potentially malicious purposes.
 
 
 ## Adding Fade-in to a non-Axate lead in

--- a/docs/wordpress-api.md
+++ b/docs/wordpress-api.md
@@ -1,6 +1,6 @@
-## Wordpress API Integration
+## WordPress API Integration
 
-Current Wordpress versions come with a REST API enabled by default, and can be consumed easily by any developer application, such as Axate.
+Current WordPress versions come with a REST API enabled by default, and can be consumed easily by any developer application, such as Axate.
 
 Let’s take for example this article,
  - https://en-gb.wordpress.org/2019/01/15/glasgow-meetup-1st-quarter-2019/


### PR DESCRIPTION
## Summary
- fix WordPress spelling across docs
- fix Subscriptions spelling
- correct typographical errors in documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a99d0d0ac8323950aefa8b11ecb86