### PR TITLE
Align branding to Axate

### DIFF
--- a/docs/amp/amp-integration.md
+++ b/docs/amp/amp-integration.md
@@ -88,16 +88,16 @@ Add the following block to the head section of your template.
 <script id="amp-access" type="application/json">
   {
     "noPingback": true,
-    "authorization": "https://staging.agate.io/api/authorisation?domain=CANONICAL_URL&rid=READER_ID&url=CANONICAL_URL&premium=true",
+    "authorization": "https://staging.axate.io/api/authorisation?domain=CANONICAL_URL&rid=READER_ID&url=CANONICAL_URL&premium=true",
     "login": {
-      "sign-in": "https://account-staging.agate.io/my-agate/sign-in?rid=READER_ID&url=CANONICAL_URL&url_from=DOCUMENT_REFERRER",
-      "sign-out": "https://staging.agate.io/api/amp_logout?url=CANONICAL_URL&url_from=DOCUMENT_REFERRER",
-      "sign-up": "https://account-staging.agate.io/my-agate/sign-up?publication_name=localhost&pub_id=localhost&url_from=CANONICAL_URL",
-      "top-up": "https://account-staging.agate.io/top-up?domain=localhost&uid=339&jwt_token=eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjozMzksImlhdCI6MTU1ODQzNzI3NiwianRpIjoiNmUxODNlYjAxZWExZjQyOWFhYjg1NjZjMjJjYjBlYWQifQ.Qjf92yBQ2XJ1jGpl7NtLtYZcYZhSoVMVMAx5OtoHJJ0&from=CANONICAL_URL",
-      "set-threshold-yes": "https://staging.agate.io/amp/set_threshold?domain=CANONICAL_URL&rid=READER_ID&url=CANONICAL_URL&url_from=DOCUMENT_REFERRER&amount=100",
-      "set-threshold-no": "https://staging.agate.io/amp/set_threshold?domain=CANONICAL_URL&rid=READER_ID&url=CANONICAL_URL&url_from=DOCUMENT_REFERRER&amount=0",
-      "authorise-charge-true": "https://staging.agate.io/amp/authorise_charge?charge_automatically=true&domain=CANONICAL_URL&rid=READER_ID&url=CANONICAL_URL&url_from=DOCUMENT_REFERRER",
-      "authorise-charge-false": "https://staging.agate.io/amp/authorise_charge?charge_automatically=false&domain=CANONICAL_URL&rid=READER_ID&url=CANONICAL_URL&url_from=DOCUMENT_REFERRER"
+      "sign-in": "https://account-staging.axate.io/my-axate/sign-in?rid=READER_ID&url=CANONICAL_URL&url_from=DOCUMENT_REFERRER",
+      "sign-out": "https://staging.axate.io/api/amp_logout?url=CANONICAL_URL&url_from=DOCUMENT_REFERRER",
+      "sign-up": "https://account-staging.axate.io/my-axate/sign-up?publication_name=localhost&pub_id=localhost&url_from=CANONICAL_URL",
+      "top-up": "https://account-staging.axate.io/top-up?domain=localhost&uid=339&jwt_token=eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjozMzksImlhdCI6MTU1ODQzNzI3NiwianRpIjoiNmUxODNlYjAxZWExZjQyOWFhYjg1NjZjMjJjYjBlYWQifQ.Qjf92yBQ2XJ1jGpl7NtLtYZcYZhSoVMVMAx5OtoHJJ0&from=CANONICAL_URL",
+      "set-threshold-yes": "https://staging.axate.io/amp/set_threshold?domain=CANONICAL_URL&rid=READER_ID&url=CANONICAL_URL&url_from=DOCUMENT_REFERRER&amount=100",
+      "set-threshold-no": "https://staging.axate.io/amp/set_threshold?domain=CANONICAL_URL&rid=READER_ID&url=CANONICAL_URL&url_from=DOCUMENT_REFERRER&amount=0",
+      "authorise-charge-true": "https://staging.axate.io/amp/authorise_charge?charge_automatically=true&domain=CANONICAL_URL&rid=READER_ID&url=CANONICAL_URL&url_from=DOCUMENT_REFERRER",
+      "authorise-charge-false": "https://staging.axate.io/amp/authorise_charge?charge_automatically=false&domain=CANONICAL_URL&rid=READER_ID&url=CANONICAL_URL&url_from=DOCUMENT_REFERRER"
     },
     "authorizationFallbackResponse": {
       "error": true,

--- a/docs/analytics-hooks.md
+++ b/docs/analytics-hooks.md
@@ -7,10 +7,10 @@ These functions can be integrated for purposes such as setting user cookies, tra
 The current flow includes the following functions:
 
 * `axateInit()`: Triggered when the Axate script is initialized.
-* `agateUserLoggedIn()`: Triggered once each time a user is logs in.
-* `agateUserLoggedOut()`: Triggered when a user logs out.
+* `axateUserLoggedIn()`: Triggered once each time a user logs in.
+* `axateUserLoggedOut()`: Triggered when a user logs out.
 * `axateUserHasAccessToContent()`: Triggered when a user gains access to content.
-* `agatePremiumContentRendered()`: Triggered when a premium article is purchased.
+* `axatePremiumContentRendered()`: Triggered when a premium article is purchased.
 
 Transaction based Hooks
 * `axateUserOnFreePeriod()`: Triggered when a user has reached the free period, only once per achievement of Free Period.
@@ -44,7 +44,7 @@ will direct you on the Axate journey to make a payment with all the required par
 Example: 
 
 ```js
-function agatePremiumContentRendered() {
+function axatePremiumContentRendered() {
 
   document.getElementById('subscription-barrier').style.display = "none";
 
@@ -58,7 +58,7 @@ Example:
 
 let userHasAxateAccount = false;
 
-function agateUserLoggedIn() {
+function axateUserLoggedIn() {
 
   userHasAxateAccount = true;
 
@@ -109,7 +109,7 @@ There are events that can be setup to trigger once the entire page is loaded.
 // Capture event once the entire page is loaded
   window.onload = function() {
     console.log("Page fully loaded"); sendPageLoadEvent();
-    function agateInit() {
+    function axateInit() {
       console.log("axate started");
     }
 };
@@ -118,7 +118,7 @@ There are events that can be setup to trigger once the entire page is loaded.
 ### MutationObserver is another technique:
 
 ```js 
-function agateInit() {
+function axateInit() {
   console.log("axate started");
 }
 ```

--- a/docs/first-party-cookies.md
+++ b/docs/first-party-cookies.md
@@ -54,7 +54,7 @@ Setting up the backend to be correctly mapped to publisher domains
 
 9. Login to Heroku
 10. Select Organization instead of Personal
-11. Select "`agate-io`"
+11. Select "`axate-io`"
 12. Add Domain
 13. `axate-api.publisher.com`
 14. Example: `axate-api.rotherhamadvertiser.co.uk`

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -37,7 +37,7 @@ The configuration contains the premium class and Axate-notice class attributes.
 
 * The script specifies that anything on the page that is attributed with the class “premium” will treated by Axate as a premium, paid-for article, i.e. it specifies the part of the page which contains the premium content.
 
-* The element on the page that is attributed with the class “agate-notice” will be used to display a page notices to users embedded within your page by Axate. This is used for registration purposes, to display a “call to action” inviting the user to register for Axate. There are also other circumstances in which Axate needs to display a page notice. Wherever you put this element determines where the page notice will appear, and the lead-in will appear above it.
+* The element on the page that is attributed with the class “axate-notice” will be used to display a page notices to users embedded within your page by Axate. This is used for registration purposes, to display a “call to action” inviting the user to register for Axate. There are also other circumstances in which Axate needs to display a page notice. Wherever you put this element determines where the page notice will appear, and the lead-in will appear above it.
 
 That’s the most technical bit done! The next step is to mark articles as premium...
 

--- a/docs/testing-and-go-live.md
+++ b/docs/testing-and-go-live.md
@@ -20,13 +20,13 @@ To include Axate on selected articles
 
 The staging code is this:
 
-``` <script async src="https://wallet-staging.agate.io/bundle.js"></script> ```
+``` <script async src="https://wallet-staging.axate.io/bundle.js"></script> ```
 
 To make it like, delete word “staging” so that it appears like this:
 
-``` <script async src="https://wallet.agate.io/bundle.js"></script> ```
+``` <script async src="https://wallet.axate.io/bundle.js"></script> ```
 
-You should see Agate briefly if the page is still loading.
+You should see Axate briefly if the page is still loading.
 
 On our side, we need to switch page notices etc over to our live database, so please let us know when you are ready to carry out the live testing.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,7 +20,7 @@ Axate relies on two cookies, one functional and one for analytics purposes, whic
 
 Users can opt-out of analytics cookies on their account page, or even block it by any AdBlocker or Tracking Blocking software on their browser, but they should allow the main functional cookie to be set.
 
-That cookie is named `agate_cookie`, and comes from `https://account.agate.io` , it is an HttpOnly cookie and always Secure to prevent any other site using it for any potentially malicous purposes.
+That cookie is named `axate_cookie`, and comes from `https://account.axate.io` , it is an HttpOnly cookie and always Secure to prevent any other site using it for any potentially malicous purposes.
 
 
 ## Adding Fade-in to a non-Axate lead in

--- a/docs/wordpress-api.md
+++ b/docs/wordpress-api.md
@@ -16,7 +16,7 @@ visible to the reader/user.
 
 https://en-gb.wordpress.org/wp-json/wp/v2/posts?slug=glasgow-meetup-1st-quarter-2019 
 
-When an Axate user pays for an article, we would fire a call to the API as above, and retrieve the content of the article so that we can replace the Paywall/Agate Notice section.
+When an Axate user pays for an article, we would fire a call to the API as above, and retrieve the content of the article so that we can replace the Paywall/Axate Notice section.
 
 Since you would not want a tech-savvy user to have access to this API publicly, we recommend setting up basic authentication, an example plugin such as ( https://github.com/WP-API/Basic-Auth ) would be enough to secure your API with a password and username.
 
@@ -25,4 +25,4 @@ One middle step is to ensure, the content is not present on the Template that is
 That means within the single.php we will remove the wp-content tag that 
 
 
-There can be further steps to secure API access, so that it can be private only to Agate servers and therefore guarantee that only a request from us would be treated as a condition to reveal content, but these require custom development, feel free to get in touch with us and we can always work on a solution together.
+There can be further steps to secure API access, so that it can be private only to Axate servers and therefore guarantee that only a request from us would be treated as a condition to reveal content, but these require custom development, feel free to get in touch with us and we can always work on a solution together.


### PR DESCRIPTION
## Summary
- replace outdated 'Agate' references with 'Axate'
- update example URLs and code snippets to use axate.io
- fix outdated function names and cookie references

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684a99d227fc83238697af602db43b8f